### PR TITLE
Remove DISABLE_NEWLINE_AUTO_RETURN on Windows to fix unintended \n behaviour

### DIFF
--- a/Crayon/ColorsOnWindows.cs
+++ b/Crayon/ColorsOnWindows.cs
@@ -15,12 +15,11 @@ namespace Crayon
 
             var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
             return GetConsoleMode(iStdOut, out uint outConsoleMode) &&
-                SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN);
+                SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         }
 
         private const int STD_OUTPUT_HANDLE = -11;
         private const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-        private const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
 
         [DllImport("kernel32.dll")]
         private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Console.WriteLine(Output.Bold().Green().Text($"starting green {Output.Red("then 
 
 ## Two modes
 
-The static methods accepting string input `Output.Red("input")` return formatted string output. This also works with nested interpolated strings `Output.Red($"input {Output.Bold("bold")}").
+The static methods accepting string input `Output.Red("input")` return formatted string output. This also works with nested interpolated strings `Output.Red($"input {Output.Bold("bold")}")`.
 
 Or building up a formatter using `Output.Bold().Red().Text("input")` where the string is only returned after closing with the `Text` method. This can also be mixed with interpolated strings.
 


### PR DESCRIPTION
Because `DISABLE_NEWLINE_AUTO_RETURN` is set on Windows systems the behaviour of `\n` is changed so it no longer outputs Carriage Return characters and only outputs Line Feeds. I suspect this is unintended behaviour for Crayon as code such as 
```csharp
Console.WriteLine(Output.BrightGreen("Hello World!\nThis is an example of a bug!"));
```
renders as
![image](https://user-images.githubusercontent.com/5931310/62833509-d38d8080-bc37-11e9-9880-9c12f2d806e9.png)
There's a good discussion of this property [here](https://github.com/Microsoft/WSL/issues/1273#issuecomment-256750463) which seems to suggest it's only intended for us on some very specific (emacs) circumstances.

Cheers for creating this tool however!